### PR TITLE
Fix deploy-breaking bugs in the dell_raid barclamp. [1/1]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,9 +18,9 @@ RAID_DEPS=("8.07.07_MegaCLI.zip" "SAS2IRCU_P16.zip")
 
 bc_needs_build() {
     for f in "${RAID_DEPS[@]}"; do
-        [[ -f $BC_CACHE/files/dell_raid/tools/$f ]] || exit 0
+        [[ -f $BC_CACHE/files/dell_raid/tools/$f ]] || return 0
     done
-    exit 1
+    return 1
 }
 
 bc_build() {
@@ -30,5 +30,5 @@ bc_build() {
     echo "http://www.lsi.com/downloads/Public/MegaRAID%20Common%20Files/8.07.07_MegaCLI.zip"
     echo
     echo "into $BC_CACHE/files/dell_raid/tools/"
-    exit 1
+    return 1
 }

--- a/chef/cookbooks/raid/recipes/install_tools.rb
+++ b/chef/cookbooks/raid/recipes/install_tools.rb
@@ -21,14 +21,7 @@ return unless ["centos","redhat"].member?(node[:platform]) && !@@is_admin
 provisioners = search(:node, "roles:provisioner-server")
 provisioner = provisioners[0] if provisioners
 web_port = provisioner["provisioner"]["web_port"]
-begin
-  address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "bmc_vlan").address
-  if (!address)
-    address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
-  end
-rescue
-  address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
-end
+address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
 provisioner_server = "#{address}:#{web_port}"
 log("Provisioner server info is #{provisioner_server}")
 

--- a/chef/cookbooks/raid/recipes/install_tools.rb
+++ b/chef/cookbooks/raid/recipes/install_tools.rb
@@ -27,8 +27,8 @@ log("Provisioner server info is #{provisioner_server}")
 
 return unless provisioner_server
 
-sas2ircu="sas2ircu"
-megacli="MegaCli-8.07.07-1.noarch.rpm"
+sas2ircu="SAS2IRCU_P16.zip"
+megacli="8.07.07_MegaCLI.zip"
 
 [sas2ircu,megacli].each do |f|
   remote_file "/tmp/#{f}" do
@@ -39,16 +39,19 @@ end
 
 bash "install sas2ircu" do
   code <<EOC
-cd /tmp
-mv sas2ircu "/usr/sbin/"
-chmod 755 "/usr/sbin/sas2ircu"
+cd /usr/sbin
+[[ -x /usr/sbin/sas2ircu ]] && exit 0
+unzip -j -o "/tmp/#{sas2ircu}" "SAS2IRCU_P16/sas2ircu_linux_x86_rel/sas2ircu"
 EOC
 end
 
 bash "install megacli" do
   code <<EOC
-cd /tmp
+cd /tmp 
 [[ -x /opt/MegaRAID/MegaCli/MegaCli64 ]] && exit 0
-rpm -Uvh #{megacli}
+for pkg in "linux/MegaCli-8.07.07-1.noarch.rpm"; do
+    unzip -j -o "#{megacli}" "$pkg"
+  rpm -Uvh "${pkg##*/}"
+done
 EOC
 end


### PR DESCRIPTION
- The install_tools recipe was not looking up the proper IP address
  for the provisioner.  It should only use the IP on the admin
  network.
- Reverted some of the packaging code to have it download the zip
  files from the provisioner and unzip them on Sledgehammer.
  
  build.sh                                     |    6 +++---
  chef/cookbooks/raid/recipes/install_tools.rb |   26 +++++++++++---------------
  2 files changed, 14 insertions(+), 18 deletions(-)

Crowbar-Pull-ID: 933a54697f9d9281f8735cb2a586167fc90de9ad

Crowbar-Release: pebbles
