### PR TITLE
Fixing size limiting for VD creation in BIOS boot mode [1/1]

### DIFF
--- a/chef/cookbooks/raid/libraries/lsi_ircu.rb
+++ b/chef/cookbooks/raid/libraries/lsi_ircu.rb
@@ -121,7 +121,7 @@ Issue the command to create a RAID volue:
 =end  
   def create_vd(controller, volume)
     ## build up the command...     
-    max_size       = (Crowbar::RAID::TERA * 2 - Crowbar::RAID::MEGA)
+    max_size       = (Crowbar::RAID::TERA * 2 - Crowbar::RAID::MEGA) / Crowbar::RAID::MEGA
     size           = nil
     curr_boot_mode = nil
     pend_boot_mode = nil


### PR DESCRIPTION
Fix for limiting size of created volume in BIOS boot mode to < 2.2TB

 chef/cookbooks/raid/libraries/lsi_ircu.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 68424a6284d19a07ef495c98873f643f3a96ca60

Crowbar-Release: mesa-1.6
