### PR TITLE
dell_raid should not be user managed. [1/1]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -16,6 +16,7 @@ barclamp:
   name: dell_raid
   display: RAID
   version: 0
+  user_managed: false
   member:
     - dell_branding
 


### PR DESCRIPTION
Wayne wants this to happen.

 crowbar.yml | 1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 07ceb2b08754707807f05f279939d55b927a010a

Crowbar-Release: mesa-1.6
