### PR TITLE
Convert some raid attributes to dell_raid attributes to enable UI to work [1/1]

### DIFF
--- a/bin/crowbar_raid
+++ b/bin/crowbar_raid
@@ -15,6 +15,6 @@
 #
 
 require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
-@barclamp = "raid"
+@barclamp = "dell_raid"
 
 main

--- a/chef/cookbooks/raid/attributes/default.rb
+++ b/chef/cookbooks/raid/attributes/default.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 
-default[:raid][:debug]=true
-default[:raid][:enable]=true
+default[:dell_raid][:debug]=true
+default[:dell_raid][:enable]=true
 
 default[:crowbar]={}
 default[:crowbar][:hardware]={}

--- a/chef/cookbooks/raid/recipes/raid-configure.rb
+++ b/chef/cookbooks/raid/recipes/raid-configure.rb
@@ -16,7 +16,7 @@
 
 include_recipe "utils"
 
-raid_enable = node[:raid][:enable] & @@centos & !@@is_admin 
+raid_enable = node[:dell_raid][:enable] & @@centos & !@@is_admin
 log("BEGIN raid-configure enabled=#{raid_enable}") {level :info} 
 
 config_name = node[:crowbar][:hardware][:raid_set] rescue config_name = "JBODOnly"

--- a/chef/cookbooks/raid/recipes/raid-report.rb
+++ b/chef/cookbooks/raid/recipes/raid-report.rb
@@ -22,7 +22,7 @@
 
 include_recipe "utils"
 
-raid_enable = node[:raid][:enable] & @@centos
+raid_enable = node[:dell_raid][:enable] & @@centos
 log("BEGIN raid-report enabled=#{raid_enable}") {level :info} 
 
 config_name = node[:crowbar][:hardware][:raid_set] rescue config_name = "JBODOnly"

--- a/chef/cookbooks/raid/recipes/raid-setboot.rb
+++ b/chef/cookbooks/raid/recipes/raid-setboot.rb
@@ -16,7 +16,7 @@
 
 include_recipe "utils"
 
-raid_enable = node[:raid][:enable] & @@centos & !@@is_admin 
+raid_enable = node[:dell_raid][:enable] & @@centos & !@@is_admin
 log("BEGIN raid-setboot enabled=#{raid_enable}") {level :info} 
 
 config_name = node[:crowbar][:hardware][:raid_set] rescue config_name = "JBODOnly"

--- a/chef/data_bags/crowbar/bc-template-dell_raid.json
+++ b/chef/data_bags/crowbar/bc-template-dell_raid.json
@@ -2,7 +2,7 @@
   "id": "bc-template-dell_raid",
   "description": "The default proposal for the raid barclamp",
   "attributes": {
-    "raid": {
+    "dell_raid": {
 	  "enable": true,
 	  "debug": false
 	 }

--- a/chef/data_bags/crowbar/bc-template-dell_raid.schema
+++ b/chef/data_bags/crowbar/bc-template-dell_raid.schema
@@ -3,7 +3,7 @@
     "id": { "type": "str", "required": true, "pattern": "/^bc-dell_raid-|^bc-template-dell_raid$/" },
     "description": { "type": "str", "required": true },
     "attributes": { "type": "map", "required": true, "mapping": {
-        "raid": { "type": "map", "required": true, "mapping": {
+        "dell_raid": { "type": "map", "required": true, "mapping": {
             "enable":  { "type": "bool", "required": true},
             "debug":  { "type": "bool", "required": true}
           }

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -16,7 +16,6 @@ barclamp:
   name: dell_raid
   display: RAID
   version: 0
-  user_managed: false
   member:
     - dell_branding
 
@@ -32,7 +31,7 @@ locale_additions:
       SingleRaid10: Single Raid 10
       JBODOnly: JBOD Only
     barclamp:
-      raid:
+      dell_raid:
         edit_deployment:
           deployment: Deployment
         edit_attributes:


### PR DESCRIPTION
Convert some raid attributes to dell_raid attributes to enable UI to work. Must test on 
actual hardware!  (DE1396)

 bin/crowbar_raid                                   |    2 +-
 chef/cookbooks/raid/attributes/default.rb          |    4 ++--
 chef/cookbooks/raid/recipes/raid-configure.rb      |    2 +-
 chef/cookbooks/raid/recipes/raid-report.rb         |    2 +-
 chef/cookbooks/raid/recipes/raid-setboot.rb        |    2 +-
 chef/data_bags/crowbar/bc-template-dell_raid.json  |    2 +-
 .../data_bags/crowbar/bc-template-dell_raid.schema |    2 +-
 crowbar.yml                                        |    3 +--
 8 files changed, 9 insertions(+), 10 deletions(-)

Crowbar-Pull-ID: 06c634300ca43cfaef7b75c7cb438302ff9e8db9

Crowbar-Release: mesa-1.6
