### PR TITLE
Update build.sh to look for external files in users home directory [1/1]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ bc_needs_build() {
         if [ ! -f $BC_CACHE/files/dell_raid/tools/$f ] ; then # check if the file is there
             if [ -f $HOME/$f ]; then                          # if not, check in $HOME
                 mkdir -p $BC_CACHE/files/dell_raid/tools
-                cp $HOME/$f $BC_CACHE/files/dell_raid/tools/$f  #grab it
+                cp $HOME/$f $BC_CACHE/files/dell_raid/tools/  #grab it
 	    else
                 rc=0 # fail if it isn't there
             fi

--- a/build.sh
+++ b/build.sh
@@ -16,11 +16,23 @@
 
 RAID_DEPS=("8.07.07_MegaCLI.zip" "SAS2IRCU_P16.zip")
 
+# This has been expanded to not only check for the exisitence of the files
+# that are needed in the cache, but to attempt to pull them in from $HOME
+# if they are not in the cache
+
 bc_needs_build() {
+    rc=1
     for f in "${RAID_DEPS[@]}"; do
-        [[ -f $BC_CACHE/files/dell_raid/tools/$f ]] || return 0
+        if [ ! -f $BC_CACHE/files/dell_raid/tools/$f ] ; then # check if the file is there
+            if [ -f $HOME/$f ]; then                          # if not, check in $HOME
+                mkdir -p $BC_CACHE/files/dell_raid/tools
+                cp $HOME/$f $BC_CACHE/files/dell_raid/tools/$f  #grab it
+	    else
+                rc=0 # fail if it isn't there
+            fi
+        fi
     done
-    return 1
+    return $rc
 }
 
 bc_build() {
@@ -29,6 +41,6 @@ bc_build() {
     echo "http://www.lsi.com/downloads/Public/Host%20Bus%20Adapters/Host%20Bus%20Adapters%20Common%20Files/SAS_SATA_6G_P16/SAS2IRCU_P16.zip"
     echo "http://www.lsi.com/downloads/Public/MegaRAID%20Common%20Files/8.07.07_MegaCLI.zip"
     echo
-    echo "into $BC_CACHE/files/dell_raid/tools/"
+    echo "into $BC_CACHE/files/dell_raid/tools/ or your home directory"
     return 1
 }


### PR DESCRIPTION
Updated build.sh to look in users home directory if the external files required for dell_raid barclamp are not already in the build cache.  
This is mainly applicable to running with the --wild-cache flag.

 build.sh | 18 +++++++++++++++---
 1 file changed, 15 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: 6b664619f247ebee3bc15942847e1f0a3a8f255c

Crowbar-Release: pebbles
