### PR TITLE
Adding support for R620 [1/2]

### DIFF
--- a/chef/cookbooks/raid/libraries/wsman_cli.rb
+++ b/chef/cookbooks/raid/libraries/wsman_cli.rb
@@ -546,7 +546,7 @@ class Crowbar
         retValue = true
         puts "Rebooting system to run RAID configuration jobs"
         %x[reboot && sleep 120]
-        retVal
+        retValue
 
         ## RKR: Need to scrub...throws errors for scheduling job
         ## if reboot job is used in the queue...


### PR DESCRIPTION
Adding support for R620
    Fixing incorrect boot mode for R620 (UEFI to BIOS)
    Fixing missing data bags for R620 (Hadoop config)
    Fixing missing data bags for R720/R720xd in Roxy (related to Hadoop)
    Limiting size of created RAID volume to 2TB or less (when in BIOS boot mode)

Fix for incorrect return value in RAID driver (on creating multiple VDs)

 chef/cookbooks/raid/libraries/wsman_cli.rb |   49 +++++++++++++++++++++++++++-
 1 file changed, 48 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 0a2799b5e11a53fda8ff7725a72576d158abc4c3

Crowbar-Release: roxy
