### PR TITLE
Fix for DE 1396 - Fix inability to edit and save dell_raid barclamp [1/1]

### DIFF
--- a/bin/crowbar_raid
+++ b/bin/crowbar_raid
@@ -15,6 +15,6 @@
 #
 
 require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
-@barclamp = "raid"
+@barclamp = "dell_raid"
 
 main

--- a/chef/cookbooks/raid/attributes/default.rb
+++ b/chef/cookbooks/raid/attributes/default.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 
-default[:raid][:debug]=true
-default[:raid][:enable]=true
+default[:dell_raid][:debug]=true
+default[:dell_raid][:enable]=true
 
 default[:crowbar]={}
 default[:crowbar][:hardware]={}

--- a/chef/cookbooks/raid/recipes/raid-configure.rb
+++ b/chef/cookbooks/raid/recipes/raid-configure.rb
@@ -16,7 +16,7 @@
 
 include_recipe "utils"
 
-raid_enable = node[:raid][:enable] & @@centos & !@@is_admin 
+raid_enable = node[:dell_raid][:enable] & @@centos & !@@is_admin
 log("BEGIN raid-configure enabled=#{raid_enable}") {level :info} 
 
 config_name = node[:crowbar][:hardware][:raid_set] rescue config_name = "JBODOnly"

--- a/chef/cookbooks/raid/recipes/raid-report.rb
+++ b/chef/cookbooks/raid/recipes/raid-report.rb
@@ -22,7 +22,7 @@
 
 include_recipe "utils"
 
-raid_enable = node[:raid][:enable] & @@centos
+raid_enable = node[:dell_raid][:enable] & @@centos
 log("BEGIN raid-report enabled=#{raid_enable}") {level :info} 
 
 config_name = node[:crowbar][:hardware][:raid_set] rescue config_name = "JBODOnly"

--- a/chef/cookbooks/raid/recipes/raid-setboot.rb
+++ b/chef/cookbooks/raid/recipes/raid-setboot.rb
@@ -16,7 +16,7 @@
 
 include_recipe "utils"
 
-raid_enable = node[:raid][:enable] & @@centos & !@@is_admin 
+raid_enable = node[:dell_raid][:enable] & @@centos & !@@is_admin
 log("BEGIN raid-setboot enabled=#{raid_enable}") {level :info} 
 
 config_name = node[:crowbar][:hardware][:raid_set] rescue config_name = "JBODOnly"

--- a/chef/data_bags/crowbar/bc-template-dell_raid.json
+++ b/chef/data_bags/crowbar/bc-template-dell_raid.json
@@ -2,7 +2,7 @@
   "id": "bc-template-dell_raid",
   "description": "The default proposal for the raid barclamp",
   "attributes": {
-    "raid": {
+    "dell_raid": {
 	  "enable": true,
 	  "debug": false
 	 }

--- a/chef/data_bags/crowbar/bc-template-dell_raid.schema
+++ b/chef/data_bags/crowbar/bc-template-dell_raid.schema
@@ -3,7 +3,7 @@
     "id": { "type": "str", "required": true, "pattern": "/^bc-dell_raid-|^bc-template-dell_raid$/" },
     "description": { "type": "str", "required": true },
     "attributes": { "type": "map", "required": true, "mapping": {
-        "raid": { "type": "map", "required": true, "mapping": {
+        "dell_raid": { "type": "map", "required": true, "mapping": {
             "enable":  { "type": "bool", "required": true},
             "debug":  { "type": "bool", "required": true}
           }

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -31,7 +31,7 @@ locale_additions:
       SingleRaid10: Single Raid 10
       JBODOnly: JBOD Only
     barclamp:
-      raid:
+      dell_raid:
         edit_deployment:
           deployment: Deployment
         edit_attributes:


### PR DESCRIPTION
Propping fix from Mesa 1.6.1 into Hadoop 2.3.1

The fix will enable editing of the dell_raid barclamp (prior to this it would crash)

 bin/crowbar_raid                                   |    2 +-
 chef/cookbooks/raid/attributes/default.rb          |    4 ++--
 chef/cookbooks/raid/recipes/raid-configure.rb      |    2 +-
 chef/cookbooks/raid/recipes/raid-report.rb         |    2 +-
 chef/cookbooks/raid/recipes/raid-setboot.rb        |    2 +-
 chef/data_bags/crowbar/bc-template-dell_raid.json  |    2 +-
 .../data_bags/crowbar/bc-template-dell_raid.schema |    2 +-
 crowbar.yml                                        |    2 +-
 8 files changed, 9 insertions(+), 9 deletions(-)

Crowbar-Pull-ID: 6ebfeebe88b7e75eb3a84635d3f1740afd0d81e7

Crowbar-Release: hadoop-2.3
