### PR TITLE
Fixing broken updates in BIOS barclamp [1/2]

### DIFF
--- a/chef/cookbooks/raid/libraries/wsman_cli.rb
+++ b/chef/cookbooks/raid/libraries/wsman_cli.rb
@@ -661,25 +661,21 @@ class Crowbar
           when :RAID0
           ## size of volume is numDisks * size of lowest disk
           ret_val = disk_size_arr[0] * disk_size_arr.length
-          puts "RKR: size of RAID volume is #{ret_val}"
 
           when :RAID1
           ## size of volume is just size of the lowest disk
           ret_val = disk_size_arr[0] 
-          puts "RKR: size of RAID volume is #{ret_val}"
 
           when :RAID10
           ## size of volume is (numDisks / 2) * size of lowest disk
           ret_val = (disk_size_arr.length / 2) * disk_size_arr[0]
-          puts "RKR: size of RAID volume is #{ret_val}"
 
           when :JBOD
           #pseudo raid0 level
           ret_val = disk_size_arr[0]
-          puts "RKR: size of RAID volume is #{ret_val}"
         end 
         ret_val = max_vol_size if (ret_val > max_vol_size)
-        puts "RKR: returning size of RAID volume to be #{ret_val}"
+        puts "DBG: returning size of RAID volume to be #{ret_val}"
         return ret_val
       end
 

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -16,7 +16,6 @@ barclamp:
   name: dell_raid
   display: RAID
   version: 0
-  user_managed: false
   member:
     - dell_branding
 


### PR DESCRIPTION
Fixes following items
    Updates broken in BIOS barclamp because provisioner server ip was not set on node
    Updates broken in BIOS barclamp because crowbar.yml changed to dell_bios from bios
        Code depending on node["bios"] was broken as a result
    Making dell_raid barclamp user manageable (visible and editable in UI)
    Removing debug messages in raid barclamp

 chef/cookbooks/raid/libraries/wsman_cli.rb |    6 +-----
 crowbar.yml                                |    1 -
 2 files changed, 1 insertion(+), 6 deletions(-)

Crowbar-Pull-ID: fb47f88dd5ff32aa605d25a7371c60927a2b573a

Crowbar-Release: roxy
