### PR TITLE
Add dell_raid and dell_bios barclamps to the Crowbar Members barclamppage in the UI [1/2]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -18,6 +18,7 @@ barclamp:
   version: 0
   member:
     - dell_branding
+    - crowbar
 
 crowbar:
   layout: 1


### PR DESCRIPTION
Add dell_raid and dell_bios barclamps to the Crowbar Members barclamp page in the UI

These barclamps needed be "members" of the crowbar group, specified in the 
crowbar.yml for each.  These yaml files are consolidated into the catalog.yml file in the 
deployed rails app. 

 crowbar.yml |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: d3e87e4085cac5930f4528f14e8528d7b4673dc2

Crowbar-Release: roxy
