### PR TITLE
Use /usr/bin/ruby in shebang's

### DIFF
--- a/chef/cookbooks/raid/libraries/lsi_megacli.rb
+++ b/chef/cookbooks/raid/libraries/lsi_megacli.rb
@@ -1,4 +1,4 @@
-#!/c/Ruby187/bin/ruby
+#!/usr/bin/ruby
 # Copyright (c) 2013 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef/cookbooks/raid/libraries/wsman_cli.rb
+++ b/chef/cookbooks/raid/libraries/wsman_cli.rb
@@ -1,4 +1,4 @@
-#!/c/Ruby187/bin/ruby
+#!/usr/bin/ruby
 # Copyright (c) 2013 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
That should be more portable accross distros.
